### PR TITLE
refine the quick search fields

### DIFF
--- a/12_refine_attributes_tsvec.sql
+++ b/12_refine_attributes_tsvec.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION public._attributes_tsvec(r public.attributes) RETURNS tsvector
+    LANGUAGE plpgsql
+    AS $$
+	-- creates tsvector from attributes record
+BEGIN
+	IF r.fk_attriblist IN (240, 245, 246, 440, 505) THEN
+	        -- titles
+		RETURN setweight (px ('t', r.text), 'B');
+ 	ELSIF r.fk_attriblist NOT IN (500, 508, 520, 540, 901, 902, 903, 904, 905) THEN		      
+		-- other attributes we want to search
+		RETURN to_tsvector ('pg_catalog.english', r.text);
+	END IF;
+
+	RETURN NULL;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public._attributes_tsvec_update(r public.attributes) RETURNS tsvector
+    LANGUAGE plpgsql
+    AS $$
+-- creates tsvector from attributes record
+DECLARE
+tsv TSVECTOR := NULL;
+BEGIN
+IF r.fk_attriblist IN (240, 245, 246, 440, 505) THEN
+        -- title
+tsv := setweight (to_tsvector (
+             'pg_catalog.english', pf2 ('tx', r.text)), 'B');
+ ELSIF r.fk_attriblist NOT IN (500, 508, 520, 540, 901, 902, 903, 904, 905) THEN      
+-- other attributes we want to search
+tsv := setweight (to_tsvector ('pg_catalog.english', r.text), 'C');
+END IF;
+
+RETURN tsv;
+END;
+$$;
+
+-- apply the revised function to the attributes table
+UPDATE public.attributes SET text = text WHERE fk_attriblist IN (500, 508, 520, 540, 906, 907);
+

--- a/gutenberg_public.sql
+++ b/gutenberg_public.sql
@@ -95,7 +95,7 @@ BEGIN
 	IF r.fk_attriblist IN (240, 245, 246, 440, 505) THEN
 	        -- titles
 		RETURN setweight (px ('t', r.text), 'B');
- 	ELSIF r.fk_attriblist < 900 THEN		      
+ 	ELSIF r.fk_attriblist NOT IN (500, 508, 520, 540, 901, 902, 903, 904, 905) THEN		      
 		-- other attributes we want to search
 		RETURN to_tsvector ('pg_catalog.english', r.text);
 	END IF;
@@ -122,7 +122,7 @@ IF r.fk_attriblist IN (240, 245, 246, 440, 505) THEN
         -- title
 tsv := setweight (to_tsvector (
              'pg_catalog.english', pf2 ('tx', r.text)), 'B');
- ELSIF r.fk_attriblist < 900 THEN      
+ ELSIF r.fk_attriblist NOT IN (500, 508, 520, 540, 901, 902, 903, 904, 905) THEN      
 -- other attributes we want to search
 tsv := setweight (to_tsvector ('pg_catalog.english', r.text), 'C');
 END IF;


### PR DESCRIPTION
omit 500, 508,52. and 540
add 900, 906, 907
adding summaries in all 520 fields  resulted in the search getting way too many hits; users asked for filters to restrict the results. A review of the fields included surface a few that we didn't want