### PR TITLE
Add migration scripts to drop terms table and fix the pg_trgm extension

### DIFF
--- a/15_drop_terms_table.sql
+++ b/15_drop_terms_table.sql
@@ -1,0 +1,2 @@
+DROP INDEX terms_trigram_idx;
+DROP TABLE terms;

--- a/16_drop_pg_trgm_artifacts.sql
+++ b/16_drop_pg_trgm_artifacts.sql
@@ -1,0 +1,54 @@
+-- NOTE: this file must be run by postgres superuser, not gutenberg!
+
+-- This SQL file removes the "unpackaged" pg_trgm artifacts from before
+-- Postgres had full extension support. These artifacts are owned by
+-- the postgres user in the gutenberg schema and thus must be removed
+-- by the postgres user.
+
+-- public functions
+DROP FUNCTION IF EXISTS similarity;
+DROP FUNCTION IF EXISTS show_trgm;
+DROP FUNCTION IF EXISTS word_similarity;
+DROP FUNCTION IF EXISTS strict_word_similarity;
+DROP FUNCTION IF EXISTS show_limit;
+DROP FUNCTION IF EXISTS set_limit;
+
+-- operators
+DROP OPERATOR IF EXISTS % (text, text);
+DROP OPERATOR IF EXISTS <% (text, text);
+DROP OPERATOR IF EXISTS %> (text, text);
+DROP OPERATOR IF EXISTS <<% (text, text);
+DROP OPERATOR IF EXISTS %>> (text, text);
+DROP OPERATOR IF EXISTS <-> (text, text);
+DROP OPERATOR IF EXISTS <<-> (text, text);
+DROP OPERATOR IF EXISTS <->> (text, text);
+DROP OPERATOR IF EXISTS <<<-> (text, text);
+DROP OPERATOR IF EXISTS <->>> (text, text);
+
+-- operator classes
+DROP OPERATOR CLASS IF EXISTS gist_trgm_ops USING GIST;
+DROP OPERATOR CLASS IF EXISTS gin_trgm_ops USING GIN;
+
+-- operator family
+DROP OPERATOR FAMILY IF EXISTS gist_trgm_ops USING GIST;
+DROP OPERATOR FAMILY IF EXISTS gin_trgm_ops USING GIN;
+
+-- internal extension functions
+DROP FUNCTION IF EXISTS gtrgm_in CASCADE;
+DROP FUNCTION IF EXISTS gtrgm_out CASCADE;
+DROP FUNCTION IF EXISTS gtrgm_compress;
+DROP FUNCTION IF EXISTS gtrgm_decompress;
+DROP FUNCTION IF EXISTS gtrgm_consistent;
+DROP FUNCTION IF EXISTS gtrgm_distance;
+DROP FUNCTION IF EXISTS gtrgm_union;
+DROP FUNCTION IF EXISTS gtrgm_same;
+DROP FUNCTION IF EXISTS gtrgm_penalty;
+DROP FUNCTION IF EXISTS gtrgm_picksplit;
+DROP FUNCTION IF EXISTS gtrgm_options;
+DROP FUNCTION IF EXISTS gin_extract_trgm (text, internal);
+DROP FUNCTION IF EXISTS gin_extract_trgm (text, internal, smallint, internal, internal);
+DROP FUNCTION IF EXISTS gin_trgm_consistent;
+DROP FUNCTION IF EXISTS set_limit;
+DROP FUNCTION IF EXISTS show_limit;
+DROP FUNCTION IF EXISTS show_trgm;
+DROP FUNCTION IF EXISTS similarity_op;

--- a/17_install_pg_trgm_extension.sql
+++ b/17_install_pg_trgm_extension.sql
@@ -1,0 +1,2 @@
+-- create the extension
+CREATE EXTENSION pg_trgm;

--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
-# pgdb
-## Postgres Database for Project Gutenberg
+# Project Gutenberg Postgres Database Definition
 
+This repo holds the active definitions for the Project Gutenberg postgres
+database, broken down by schema, in:
+```
+gutenberg_cherrypy.sql
+gutenberg_public.sql
+gutenberg_reviews.sql
+gutenberg_robots.sql
+gutenberg_scores.sql
+```
+
+## Creating the `.sql` files
+These definitions were created from the active ibiblio database with:
+```bash
+export DB_HOST=gutenberg-pg1.int.ibiblio.org
+
+# dump non-public schemas
+for schema in cherrypy reviews robots scores; do
+    pg_dump -h $DB_HOST -U gutenberg -s gutenberg -n $schema > gutenberg_$schema.sql
+done
+
+# dump the public schema
+# we have to do this separately to get the pg_tgrm extension as it lives in the
+# database's public schema, but isn't part of the public schema
+pg_dump -h $DB_HOST -U gutenberg -s gutenberg -N cherrypy -N reviews -N robots -N scores  > gutenberg_public.sql
+```
+
+It also includes migration scripts, prefixed by `##_`, for upgrading from prior versions.
+
+## Updates
 - In a branch, add a migration file to the repo, prefixed with digits according to sequence.
-- open PR
-- Apply the migration to gutenberg_dev database `psql -h dbhost -U gutenberg -s gutenberg_dev -f XX_migration_name.sql`
-- snapshot the migrated schema `pg_dump -h dbhost -U gutenberg -s gutenberg_dev -n public` and commit to branch
-- review results and apply to gutenberg database
+- Open PR
+- Apply the migration to `gutenberg_dev` database `psql -h dbhost -U gutenberg -s gutenberg_dev -f XX_migration_name.sql`
+- Snapshot the migrated schema from the `gutenberg_dev` database using the process above and commit to branch
+- Review results and apply to `gutenberg` database
 
 ## backupuser
 Privileges for user `backupuser` are set in:
@@ -24,7 +52,7 @@ This user can make database dumps remotely from a management node by:
 
 The database can be restored from one of these dumps by running locally on dbhost:
 
-```
+```bash
 dropdb gutenberg_dev
 createdb -T template0 gutenberg_dev
 psql gutenberg_dev < guten_dev_full.sql

--- a/gutenberg_public.sql
+++ b/gutenberg_public.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 1bNdOMPkuChSVE7xa78akeC6C2SvVDOaAig43n4O503ifg76q7jD5j0zOjLMLtg
+\restrict 5lhHjOAwSxYf12EiMmDlnVg1mUVGsX8dzavmUkP7mQgN5XogS7VnHDMenrHMuBA
 
 -- Dumped from database version 16.13
 -- Dumped by pg_dump version 16.13
@@ -22,61 +22,24 @@ SET row_security = off;
 -- Name: public; Type: SCHEMA; Schema: -; Owner: postgres
 --
 
-CREATE SCHEMA public;
+-- *not* creating schema, since initdb creates it
 
 
 ALTER SCHEMA public OWNER TO postgres;
 
 --
--- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
 --
 
-COMMENT ON SCHEMA public IS 'standard public schema';
-
-
---
--- Name: gtrgm; Type: SHELL TYPE; Schema: public; Owner: postgres
---
-
-CREATE TYPE public.gtrgm;
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 
 --
--- Name: gtrgm_in(cstring); Type: FUNCTION; Schema: public; Owner: postgres
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: 
 --
 
-CREATE FUNCTION public.gtrgm_in(cstring) RETURNS public.gtrgm
-    LANGUAGE c STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_in';
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
-
-ALTER FUNCTION public.gtrgm_in(cstring) OWNER TO postgres;
-
---
--- Name: gtrgm_out(public.gtrgm); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_out(public.gtrgm) RETURNS cstring
-    LANGUAGE c STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_out';
-
-
-ALTER FUNCTION public.gtrgm_out(public.gtrgm) OWNER TO postgres;
-
---
--- Name: gtrgm; Type: TYPE; Schema: public; Owner: postgres
---
-
-CREATE TYPE public.gtrgm (
-    INTERNALLENGTH = variable,
-    INPUT = public.gtrgm_in,
-    OUTPUT = public.gtrgm_out,
-    ALIGNMENT = int4,
-    STORAGE = plain
-);
-
-
-ALTER TYPE public.gtrgm OWNER TO postgres;
 
 SET default_tablespace = '';
 
@@ -857,116 +820,6 @@ $$;
 ALTER FUNCTION public.filing(title text, nonfiling integer) OWNER TO gutenberg;
 
 --
--- Name: gin_extract_trgm(text, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gin_extract_trgm(text, internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gin_extract_trgm';
-
-
-ALTER FUNCTION public.gin_extract_trgm(text, internal) OWNER TO postgres;
-
---
--- Name: gin_extract_trgm(text, internal, smallint, internal, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gin_extract_trgm(text, internal, smallint, internal, internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gin_extract_trgm';
-
-
-ALTER FUNCTION public.gin_extract_trgm(text, internal, smallint, internal, internal) OWNER TO postgres;
-
---
--- Name: gin_trgm_consistent(internal, smallint, text, integer, internal, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gin_trgm_consistent(internal, smallint, text, integer, internal, internal) RETURNS boolean
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gin_trgm_consistent';
-
-
-ALTER FUNCTION public.gin_trgm_consistent(internal, smallint, text, integer, internal, internal) OWNER TO postgres;
-
---
--- Name: gtrgm_compress(internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_compress(internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_compress';
-
-
-ALTER FUNCTION public.gtrgm_compress(internal) OWNER TO postgres;
-
---
--- Name: gtrgm_consistent(internal, text, integer, oid, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_consistent(internal, text, integer, oid, internal) RETURNS boolean
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_consistent';
-
-
-ALTER FUNCTION public.gtrgm_consistent(internal, text, integer, oid, internal) OWNER TO postgres;
-
---
--- Name: gtrgm_decompress(internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_decompress(internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_decompress';
-
-
-ALTER FUNCTION public.gtrgm_decompress(internal) OWNER TO postgres;
-
---
--- Name: gtrgm_penalty(internal, internal, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_penalty(internal, internal, internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_penalty';
-
-
-ALTER FUNCTION public.gtrgm_penalty(internal, internal, internal) OWNER TO postgres;
-
---
--- Name: gtrgm_picksplit(internal, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_picksplit(internal, internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_picksplit';
-
-
-ALTER FUNCTION public.gtrgm_picksplit(internal, internal) OWNER TO postgres;
-
---
--- Name: gtrgm_same(public.gtrgm, public.gtrgm, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_same(public.gtrgm, public.gtrgm, internal) RETURNS internal
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_same';
-
-
-ALTER FUNCTION public.gtrgm_same(public.gtrgm, public.gtrgm, internal) OWNER TO postgres;
-
---
--- Name: gtrgm_union(bytea, internal); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.gtrgm_union(bytea, internal) RETURNS integer[]
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'gtrgm_union';
-
-
-ALTER FUNCTION public.gtrgm_union(bytea, internal) OWNER TO postgres;
-
---
 -- Name: pf(text, text); Type: FUNCTION; Schema: public; Owner: gutenberg
 --
 
@@ -1057,61 +910,6 @@ $$;
 ALTER FUNCTION public.pxtest(p text, t text) OWNER TO gutenberg;
 
 --
--- Name: set_limit(real); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.set_limit(real) RETURNS real
-    LANGUAGE c STRICT
-    AS '$libdir/pg_trgm', 'set_limit';
-
-
-ALTER FUNCTION public.set_limit(real) OWNER TO postgres;
-
---
--- Name: show_limit(); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.show_limit() RETURNS real
-    LANGUAGE c STABLE STRICT
-    AS '$libdir/pg_trgm', 'show_limit';
-
-
-ALTER FUNCTION public.show_limit() OWNER TO postgres;
-
---
--- Name: show_trgm(text); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.show_trgm(text) RETURNS text[]
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'show_trgm';
-
-
-ALTER FUNCTION public.show_trgm(text) OWNER TO postgres;
-
---
--- Name: similarity(text, text); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.similarity(text, text) RETURNS real
-    LANGUAGE c IMMUTABLE STRICT
-    AS '$libdir/pg_trgm', 'similarity';
-
-
-ALTER FUNCTION public.similarity(text, text) OWNER TO postgres;
-
---
--- Name: similarity_op(text, text); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.similarity_op(text, text) RETURNS boolean
-    LANGUAGE c STABLE STRICT
-    AS '$libdir/pg_trgm', 'similarity_op';
-
-
-ALTER FUNCTION public.similarity_op(text, text) OWNER TO postgres;
-
---
 -- Name: subjects_tsvec_triggerfunc(); Type: FUNCTION; Schema: public; Owner: gutenberg
 --
 
@@ -1130,77 +928,6 @@ $$;
 
 
 ALTER FUNCTION public.subjects_tsvec_triggerfunc() OWNER TO gutenberg;
-
---
--- Name: %; Type: OPERATOR; Schema: public; Owner: postgres
---
-
-CREATE OPERATOR public.% (
-    FUNCTION = public.similarity_op,
-    LEFTARG = text,
-    RIGHTARG = text,
-    COMMUTATOR = OPERATOR(public.%),
-    RESTRICT = contsel,
-    JOIN = contjoinsel
-);
-
-
-ALTER OPERATOR public.% (text, text) OWNER TO postgres;
-
---
--- Name: gin_trgm_ops; Type: OPERATOR FAMILY; Schema: public; Owner: postgres
---
-
-CREATE OPERATOR FAMILY public.gin_trgm_ops USING gin;
-ALTER OPERATOR FAMILY public.gin_trgm_ops USING gin ADD
-    OPERATOR 1 public.%(text,text) ,
-    FUNCTION 1 (text, text) btint4cmp(integer,integer) ,
-    FUNCTION 4 (text, text) public.gin_trgm_consistent(internal,smallint,text,integer,internal,internal);
-
-
-ALTER OPERATOR FAMILY public.gin_trgm_ops USING gin OWNER TO postgres;
-
---
--- Name: gin_trgm_ops; Type: OPERATOR CLASS; Schema: public; Owner: postgres
---
-
-CREATE OPERATOR CLASS public.gin_trgm_ops
-    FOR TYPE text USING gin FAMILY public.gin_trgm_ops AS
-    STORAGE integer ,
-    FUNCTION 2 (text, text) public.gin_extract_trgm(text,internal) ,
-    FUNCTION 3 (text, text) public.gin_extract_trgm(text,internal,smallint,internal,internal);
-
-
-ALTER OPERATOR CLASS public.gin_trgm_ops USING gin OWNER TO postgres;
-
---
--- Name: gist_trgm_ops; Type: OPERATOR FAMILY; Schema: public; Owner: postgres
---
-
-CREATE OPERATOR FAMILY public.gist_trgm_ops USING gist;
-ALTER OPERATOR FAMILY public.gist_trgm_ops USING gist ADD
-    OPERATOR 1 public.%(text,text) ,
-    FUNCTION 3 (text, text) public.gtrgm_compress(internal) ,
-    FUNCTION 4 (text, text) public.gtrgm_decompress(internal);
-
-
-ALTER OPERATOR FAMILY public.gist_trgm_ops USING gist OWNER TO postgres;
-
---
--- Name: gist_trgm_ops; Type: OPERATOR CLASS; Schema: public; Owner: postgres
---
-
-CREATE OPERATOR CLASS public.gist_trgm_ops
-    FOR TYPE text USING gist FAMILY public.gist_trgm_ops AS
-    STORAGE public.gtrgm ,
-    FUNCTION 1 (text, text) public.gtrgm_consistent(internal,text,integer,oid,internal) ,
-    FUNCTION 2 (text, text) public.gtrgm_union(bytea,internal) ,
-    FUNCTION 5 (text, text) public.gtrgm_penalty(internal,internal,internal) ,
-    FUNCTION 6 (text, text) public.gtrgm_picksplit(internal,internal) ,
-    FUNCTION 7 (text, text) public.gtrgm_same(public.gtrgm,public.gtrgm,internal);
-
-
-ALTER OPERATOR CLASS public.gist_trgm_ops USING gist OWNER TO postgres;
 
 --
 -- Name: aliases; Type: TABLE; Schema: public; Owner: gutenberg
@@ -1784,19 +1511,6 @@ ALTER SEQUENCE public.subjects_pk_seq OWNER TO gutenberg;
 
 ALTER SEQUENCE public.subjects_pk_seq OWNED BY public.subjects.pk;
 
-
---
--- Name: terms; Type: TABLE; Schema: public; Owner: gutenberg
---
-
-CREATE TABLE public.terms (
-    word text,
-    ndoc integer,
-    nentry integer
-);
-
-
-ALTER TABLE public.terms OWNER TO gutenberg;
 
 --
 -- Name: tweets; Type: TABLE; Schema: public; Owner: gutenberg
@@ -2512,13 +2226,6 @@ CREATE INDEX ix_subjects_downloads ON public.subjects USING btree (downloads);
 --
 
 CREATE INDEX ix_subjects_release_date ON public.subjects USING btree (release_date);
-
-
---
--- Name: terms_trigram_idx; Type: INDEX; Schema: public; Owner: gutenberg
---
-
-CREATE INDEX terms_trigram_idx ON public.terms USING gin (word public.gin_trgm_ops);
 
 
 --
@@ -3310,5 +3017,5 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT ON TABL
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 1bNdOMPkuChSVE7xa78akeC6C2SvVDOaAig43n4O503ifg76q7jD5j0zOjLMLtg
+\unrestrict 5lhHjOAwSxYf12EiMmDlnVg1mUVGsX8dzavmUkP7mQgN5XogS7VnHDMenrHMuBA
 


### PR DESCRIPTION
Remove the `terms` table and fix the partial install of the `pg_trgm` extension. These migration scripts have been successfully run on the dev database at ibiblio.

The production database on ibiblio already has the corrected `pg_trgm` extension installed but the `terms` table still exists until we finish the updated autocat3 deployment next week and the pg-static changes in https://github.com/gutenbergtools/pg-static/pull/19.

Extensions aren't actually _tied_ to schemas so `pg_dump -h dbhost -U gutenberg -s gutenberg_dev -n public` to dump just the public schema won't actually include the SQL to create the extension. We work around this for public by dumping everything except the other schemas.